### PR TITLE
chore(git-hooks): Allow direct commits to main

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,7 +5,4 @@ branch="$(git branch --show-current)"
 if [ -z "$branch" ]; then # Check for empty branch name (detached HEAD)
 	echo "🚫 You are in a detached HEAD state. Checkout a branch before committing."
 	exit 1
-elif [ "$branch" = "main" ]; then # Check for direct commit to main
-	echo "🚫 Direct commits to main branch are not allowed. Create a separate branch."
-	exit 1
 fi


### PR DESCRIPTION
Removes the check from the pre-commit hook that blocked commits on the 'main' branch to simplify the development workflow.